### PR TITLE
Update P4-16-Spec files to 1.2.5v

### DIFF
--- a/p4-spec-next/P4-16-spec.adoc
+++ b/p4-spec-next/P4-16-spec.adoc
@@ -1,6 +1,6 @@
 = P4~16~ Language Specification : The P4 Language Consortium
 :doctype: book
-:revnumber: v1.2.4
+:revnumber: v1.2.5
 :imagesdir: resources/figs
 :font-size: 10
 :sectnums: 5
@@ -1215,13 +1215,13 @@ literal. Here are some examples of numeric literals:
 [#sec-string-literals]
 ===== String literals
 
-String literals (string constants) are specified as an arbitrary
-sequence of 8-bit characters, enclosed within double quote characters `"`
-(ASCII code 34). Strings start with a double quote character
-and extend to the first double quote sign which is not immediately
-preceded by an odd number of backslash characters (ASCII code 92). P4
-does not make any validity checks on strings (i.e., it does not check
-that strings represent legal UTF-8 encodings).
+String literals are specified as an arbitrary sequence of 8-bit
+characters, enclosed within double quote characters `"` (ASCII code
+34). Strings start with a double quote character and extend to the
+first double quote sign which is not immediately preceded by an odd
+number of backslash characters (ASCII code 92). P4 does not make any
+validity checks on strings (i.e., it does not check that strings
+represent legal UTF-8 encodings).
 
 Since P4 does not provide any operations on strings,
 string literals are generally passed unchanged through the P4 compiler to
@@ -1440,7 +1440,7 @@ Each parameter may be labeled with a direction:
 ** For anything other than an action, e.g. a control, parser, or
    function, a directionless parameter means that the value supplied
    as an argument in a call must be a compile-time known value
-   (see <<sec-ct-constants>>).
+   (see <<sec-compile-time-known>>).
 ** For an action, a directionless parameter indicates that it is
    "action data".  See <<sec-actions>> for the meaning of
    action data, but its meaning includes the following possibilities:
@@ -1450,6 +1450,8 @@ Each parameter may be labeled with a direction:
 *** The parameter's value is provided by the control plane software
     when an entry is added to a table that uses that action.  See
     <<sec-actions>>.
+
+A directionless parameter of extern object type is passed by reference.
 
 Direction `out` parameters are always initialized at the beginning of
 execution of the portion of the program that has the `out` parameters,
@@ -1617,8 +1619,8 @@ directions:
 * All constructor parameters are evaluated at compilation-time, and in
   consequence they must all be directionless (they cannot be `in`,
   `out`, or `inout`); this applies to `package`, `control`, `parser`,
-  and `extern` objects. Values for these parameters must be specified
-  at compile-time, and must evaluate to compile-time known values.
+  and `extern` objects. Expressions for these parameters must be supplied
+  at compile-time, and they must evaluate to compile-time known values.
   See <<sec-parameterization>> for further details.
 * For actions all directionless parameters must be at the end of the
   parameter list.  When an action appears in a ``table``'s `actions`
@@ -1630,8 +1632,9 @@ directions:
   including values for the directionless parameters. The directionless
   parameters in this case behave like `in` parameters.
   See <<sec-invoke-actions>> for further details.
-* Default parameter values are only allowed for 'in' or direction-less parameters;
-  these values must evaluate to compile-time constants.
+* Default expressions are only allowed for 'in' or direction-less
+  parameters, and the expressions supplied as defaults must be
+  compile-time known values.
 * If parameters with default values do not appear at the
   end of the list of parameters, invocations that use
   the default values must use named arguments, as in the following
@@ -1700,7 +1703,8 @@ control nothing(inout Empty h, inout Empty m) {
 parser parserProto<H, M>(packet_in p, out H h, inout M m);
 control controlProto<H, M>(inout H h, inout M m);
 
-package pack<HP, MP, HC, MC>(@optional parserProto<HP, MP> _parser,  // optional parameter
+package pack<HP, MP, HC, MC>(
+    @optional parserProto<HP, MP> _parser,  // optional parameter
                              controlProto<HC, MC> _control = nothing()); // default parameter value
 
 pack() main;   // No value for _parser, _control is an instance of nothing()
@@ -1773,12 +1777,12 @@ P4 supports the following built-in base types:
   restricted circumstances.
 * The `error` type, which is used to convey errors in a
   target-independent, compiler-managed way.
-* The `string` type, which can be used only for compile-time
-  constant string values.
+* The `string` type, which can be used with compile-time known
+  values of type string.
 * The `match_kind` type, which is used for describing the implementation of
   table lookups,
 * `bool`, which represents Boolean values
-* `int`, which represents arbitrary-sized constant integer values
+* `int`, which represents arbitrary-sized integer values
 * Bit-strings of fixed width, denoted by `bit<>`
 * Fixed-width signed integers represented using two's complement `int<>`
 * Bit-strings of dynamically-computed width with a fixed maximum width `varbit<>`
@@ -1797,7 +1801,7 @@ restricted places in P4 programs.
 ==== The error type
 
 The error type contains opaque distinct values that can be used to signal
-errors. It is written as `error`. New constants of the error type
+errors. It is written as `error`. New elements of the error type
 are defined with the syntax:
 
 [source,bison]
@@ -1805,7 +1809,7 @@ are defined with the syntax:
 include::grammar.adoc[tag=errorDeclaration]
 ----
 
-All `error` constants are inserted into the `error`
+All elements of the `error` type are inserted into the `error`
 namespace, irrespective of the place where an error is
 defined. `error` is similar to an enumeration (`enum`)
 type in other languages. A program can contain multiple `error` declarations, which
@@ -1813,7 +1817,7 @@ the compiler will merge together. It is an error to declare the same
 identifier multiple times. Expressions of type `error` are
 described in <<sec-error-exprs>>.
 
-For example, the following declaration creates two constants of `error`
+For example, the following declaration creates two elements of the `error`
 type (these errors are declared in the P4 core library):
 
 [source,p4]
@@ -1871,20 +1875,19 @@ string values; one cannot declare variables with a `string` type.
 Parameters with type `string` can be only directionless (see
 <<sec-calling-convention>>).
 P4 does not support string manipulation
-in the dataplane; the `string` type is only allowed for denoting
-compile-time constant string values.  These may be useful, for
-example, a specific target architecture may support an extern function
-for logging with the following signature:
+in the dataplane; the `string` type is only allowed for describing
+compile-time known values (i.e., string literals, as discussed in
+Section <<sec-string-literals>>). Even so, the string type is useful,
+for example, in giving the type signature for extern functions such as
+the following:
 
 [source,p4]
 ----
 extern void log(string message);
 ----
 
-The only strings that can appear in a P4 program are constant string
-literals, described in <<sec-string-literals>>.  For example,
-the following annotation indicates that a specific name should be used
-for a table when generating the control-plane API:
+As another example, the following annotation indicates that the specified
+name should be used for a given table in the generated control-plane API:
 
 [source,p4]
 ----
@@ -1931,7 +1934,7 @@ restrictions may include:
 * Alignment and padding constraints (e.g., arithmetic may only be
   supported on widths which are an integral number of bytes).
 * Constraints on some operands (e.g., some architectures may only
-  support multiplications with small constants, or shifts with small
+  support multiplications by small values, or shifts with small
   values).
 
 The documentation supplied with a target should clearly specify restrictions, and
@@ -1947,14 +1950,14 @@ behavior should match this specification.
 An unsigned integer (which we also call a "bit-string") has an
 arbitrary width, expressed in bits. A bit-string of width `W` is
 declared as: `bit<W>`. `W` must be an expression that evaluates to a
-compile-time known value (see <<sec-ct-constants>>) that is a
+local compile-time known value (see <<sec-compile-time-known>>) that is a
 non-negative integer.  When using an expression for
-the size, the expression must be parenthesized and compile-time known.
+the size, the expression must be parenthesized.
 Bitstrings with width 0 are
 allowed; they have no actual bits, and can only have the value 0.  See
 <<sec-uninitialized-values-and-writing-invalid-headers>> for additional details.
 Note that `bit<W>` type refers to both cases of `bit<W>`
-and `bit<(expression)>` where the width is compile-time known.
+and `bit<(expression)>` where the width is a compile-time known value.
 
 [source,p4]
 ----
@@ -1983,11 +1986,13 @@ described in <<sec-bit-ops>>.
 [#sec-signed-integers]
 ===== Signed Integers
 
-Signed integers are represented using two's complement. An integer with `W`
-bits is declared as: `int<W>`. `W` must be an expression that evaluates to
-a compile-time known value that is a positive integer.
-Note that `int<W>` type refers to both cases of `int<W>`
-and `int<(expression)>` where the width is compile-time known.
+Signed integers are represented using two's complement. An integer
+with `W` bits is declared as: `int<W>`. `W` must be an expression that
+evaluates to a local compile-time known (see Section
+<<sec-compile-time-known>>) value that is a non-negative integer.  Note
+that `int<W>` type refers to both cases of `int<W>` and
+`int<(expression)>` where the width is a local compile-time known
+value.
 
 Bits within an integer are numbered from `0` to `W-1`. Bit `0`
 is the least significant, and bit `W-1` is the sign bit.
@@ -2015,13 +2020,14 @@ values, P4 provides a special bit-string type whose size is set at
 runtime, called a `varbit`.
 
 The type `varbit<W>` denotes a bit-string with a width of at most `W`
-bits, where `W` must be a non-negative integer that is a compile-time
-known value. For example, the type `varbit<120>` denotes the type
-of bit-string values that may have between 0 and 120 bits. Most
-operations that are applicable to fixed-size bit-strings (unsigned
-numbers) *cannot* be performed on dynamically sized bit-strings.
-Note that `varbit<W>` type refers to both cases of `varbit<W>`
-and `varbit<(expression)>` where the width is compile-time known.
+bits, where `W` is a local compile-time known value (see Section
+<<#sec-compile-time-known>>) that is a non-negative integer.  For
+example, the type `varbit<120>` denotes the type of bit-string values
+that may have between 0 and 120 bits. Most operations that are
+applicable to fixed-size bit-strings (unsigned numbers) *cannot* be
+performed on dynamically sized bit-strings.  Note that `varbit<W>`
+type refers to both cases of `varbit<W>` and `varbit<(expression)>`
+where the width is a compile-time known value.
 
 P4 architectures may impose additional constraints on varbit types:
 for example, they may limit the maximum size, or they may require `varbit`
@@ -2064,13 +2070,13 @@ parameters.
 
 ===== Integer literal types
 
-The types of integer literals (constants) are as follows:
+The types of integer literals are as follows:
 
-* A simple integer constant has type `int`.
-* A non-negative integer prefixed with an integer width `N` and the
-  character `w` has type `bit<N>`.
-* An integer prefixed with an integer width `N` and the character `s`
-  has type `int<N>`.
+* An integer with no type prefix has type `int`.
+* A non-negative integer prefixed with an integer width `W` and the
+  character `w` has type `bit<W>`
+* An integer prefixed with an integer width `W` and the character `s`
+  has type `int<W>`
 
 The table below shows several examples of integer literals and their
 types. For additional examples of literals see <<sec-literals>>.
@@ -2161,9 +2167,9 @@ enum Suits { Clubs, Diamonds, Hearths, Spades }
 ----
 
 introduces a new enumeration type, which contains four
-constants---e.g., `Suits.Clubs`. An `enum` declaration
+elements---e.g., `Suits.Clubs`. An `enum` declaration
 introduces a new identifier in the current scope for naming the
-created type along with its distinct constants.
+created type along with its distinct elements.
 The underlying representation of the `Suits` enum is not
 specified, so their "size" in bits is not specified (it is
 target-specific).
@@ -2174,8 +2180,8 @@ allowed to have fields with such `enum` types. This requires the programmer prov
 an associated integer value for each symbolic entry in the enumeration.
 The symbol `typeRef` in the grammar above must be one of the following types:
 
-* an unsigned integer, i.e. `bit<W>` for some compile-time known `W`.
-* a signed integer, i.e. `int<W>` for some compile-time known `W`.
+* an unsigned integer, i.e. `bit<W>` for some local compile-time known value `W`.
+* a signed integer, i.e. `int<W>` for some local compile-time known value `W`.
 * a type name declared via `typedef`, where the base type of that type is either
 one of the types listed above, or another `typedef` name that meets these conditions.
 For example, the declaration
@@ -2191,13 +2197,13 @@ enum bit<16> EtherType {
 }
 ----
 
-introduces a new enumeration type, which contains five constants---e.g.,
+introduces a new enumeration type, which contains five elements---e.g.,
 `EtherType.IPV4`.  This `enum` declaration specifies the fixed-width unsigned integer representation
 for each entry in the `enum` and provides an underlying type: `bit<16>`.
-This type of `enum` declaration can be thought of as declaring a new `bit<16>`
+This kind of `enum` declaration can be thought of as declaring a new `bit<16>`
 type, where variables or fields of this type are expected to be unsigned 16-bit
 integer values, and the mapping of symbolic to numeric values defined by the
-`enum` are effectively constants defined as a part of this type.  In this way,
+`enum` are also defined as a part of this declaration.  In this way,
 an `enum` with an underlying type can be thought of as being a type derived
 from the underlying type carrying equality, assignment, and casts to/from the
 underlying type.
@@ -2304,14 +2310,13 @@ header ipv6_t {
 }
 ----
 
-Headers that do not contain any `varbit` field are "fixed
-size." Headers containing `varbit` fields have "variable
-size." The size (in bits) of a fixed-size header is a constant, and it
-is simply the sum of the sizes of all component fields (without
-counting the validity bit). There is no padding or alignment of the
-header fields. Targets may impose additional constraints on
-header types---e.g., restricting headers to sizes that are an integer
-number of bytes.
+Headers that do not contain any `varbit` field are "fixed size."
+Headers containing `varbit` fields have "variable size." The size (in
+bits) of a fixed-size header is simply the sum of the sizes of all
+component fields (without counting the validity bit). There is no
+padding or alignment of the header fields. Targets may impose
+additional constraints on header types---e.g., restricting headers to
+sizes that are an integer number of bytes.
 
 For example, the following declaration describes a typical Ethernet
 header:
@@ -2379,12 +2384,13 @@ defined as:
 include::grammar.adoc[tag=headerStackType]
 ----
 
-where `typeName` is the name of a header or header union type. For a header stack `hs[n]`,
-the term `n` is the maximum defined size, and must be
-a positive integer that is a compile-time known value. Nested header
-stacks are not supported. At runtime a stack contains `n` values
-with type `typeName`, only some of which may be valid. Expressions
-on header stacks are discussed in <<sec-expr-hs>>.
+where `typeName` is the name of a header or header union type. For a
+header stack `hs[n]`, the term `n` is the maximum defined size, and
+must be a local compile-time known value that is a positive
+integer. Nested header stacks are not supported. At runtime a stack
+contains `n` values with type `typeName`, only some of which may be
+valid. Expressions on header stacks are discussed in Section
+<<#sec-expr-hs>>.
 
 For example, the following declarations,
 
@@ -2516,7 +2522,7 @@ arbitrary-precision integer, without a width specified.
 
 [.center,%autowidth]
 |===
-| Element type 5+^| Container type
+| Element type 5+^| Container kind  
 
 |                | header    | header_union | struct or tuple | list | header stack
 
@@ -2538,19 +2544,19 @@ arbitrary-precision integer, without a width specified.
 
 | `bool`         | allowed   | error   |  allowed | allowed | error
 
-| `enum`         | allowed footnote:enum_header[an `enum` type used as a field in a `header` must specify a underlying type and representation for `enum` elements.]     | error   |  allowed | allowed | error
+| `enumeration types`         | allowed footnote:enum_header[an `enum` type used as a field in a `header` must specify a underlying type and representation for `enum` elements.]     | error   |  allowed | allowed | error
 
-| `header`       | error     | allowed |  allowed | allowed | allowed
+| `header types`       | error     | allowed |  allowed | allowed | allowed
 
-| header stack   | error     | error   |  allowed | allowed | error
+| `header stacks`   | error     | error   |  allowed | allowed | error
 
-| `header_union` | error     | error   |  allowed | allowed | allowed
+| `header_unions` | error     | error   |  allowed | allowed | allowed
 
-| `struct`       | allowed footnote:struct_header[a `struct` or nested `struct` type that has the same properties, used as a field in a `header` must contain only `bit<W>`, `int<W>`, a serializable `enum`, or a `bool`.]   | error   |  allowed | allowed | error
+| `struct types`       | allowed footnote:struct_header[a `struct` or nested `struct` type that has the same properties, used as a field in a `header` must contain only `bit<W>`, `int<W>`, a serializable `enum`, or a `bool`.]   | error   |  allowed | allowed | error
 
-| `tuple`        | error     | error   |  allowed | allowed | error
+| `tuple types`        | error     | error   |  allowed | allowed | error
 
-| `list`         | error     | error   |  error   | allowed | error
+| `list types`         | error     | error   |  error   | allowed | error
 
 |===
 
@@ -2572,41 +2578,48 @@ The table below lists all types that may appear as base types in a
 
 [.center,cols="1,1,1",width=70%]
 |===
-| Base type B      | `typedef B <name>` | `type B <name>`
+| Base type B         | `typedef B <name>` | `type B <name>`
 
-| `bit<W>`         | allowed            | allowed
+| `bit<W>`            | allowed            | allowed
 
-| `int<W>`         | allowed            | allowed
+| `int<W>`            | allowed            | allowed
 
-| `varbit<W>`      | allowed            | error
+| `varbit<W>`         | allowed            | error
 
-| `int`            | allowed            | error
+| `int`               | allowed            | error
 
-| `void`           | error              | error
+| `void`              | error              | error
 
-| `error`          | allowed            | error
+| `string`            | error              | error
 
-| `match_kind`     | error              | error
+| `error`             | allowed            | error
 
-| `bool`           | allowed            | allowed
+| `match_kind`        | error              | error
 
-| `enum`           | allowed            | error
+| `bool`              | allowed            | allowed
 
-| `header`         | allowed            | error
+| `enumeration types` | allowed            | error
 
-| header stack     | allowed            | error
+| `header types`      | allowed            | error
 
-| `header_union`   | allowed            | error
+| `header stacks`     | allowed            | error
 
-| `struct`         | allowed            | error
+| `header_unions`     | allowed            | error
 
-| `tuple`          | allowed            | error
+| `struct types`      | allowed            | error
+
+| `tuple types`       | allowed            | error
+
+| `list types`       | allowed            | error
 
 | a `typedef` name | allowed            | allowed footnote:type_allowed[`type B <name>` is allowed for a type name `B` defined via `typedef X B` if `type X <name>` is allowed.]
 
 | a `type` name    | allowed            | allowed
 |===
 
+Rationale: So far, no clear motivation for allowing `typedef` for `void`
+and `match_kind` was presented. Therefore, to be on the safe side this
+is disallowed.
 
 [#sec-synth-types]
 ==== Synthesized data types
@@ -3535,8 +3548,8 @@ to bit-strings of the same width:
 
 Bit-strings also support the following operations:
 
-* Logical shift left and right by a (not-necessarily-known-at-compile-time)
-  non-negative integer value, denoted by `<<` and `>>` respectively.
+* Logical shift left and right by a (which need not be
+  a compile-time known value) non-negative integer value, denoted by `<<` and `>>` respectively.
   In a shift, the left operand is unsigned, and right operand must be either an
   expression of type `bit<S>` or a non-negative integer value that is known at
   compile time.  The result has the same type as the left operand.
@@ -3544,7 +3557,7 @@ Bit-strings also support the following operations:
   produces a result where all bits are zero.
 * Extraction of a set of contiguous bits, also known as a slice,
   denoted by `[H:L]`, where `H` and `L` must be expressions that evaluate to
-  non-negative compile-time known values, and `H >= L`. The types of `H` and `L`
+  non-negative, local compile-time known values, and `H >= L`. The types of `H` and `L`
   (which do not need to be identical) must be numeric (<<sec-numeric-values>>).
   The result is a bit-string of width `H - L + 1`, including the bits numbered
   from `L` (which becomes the least significant bit of the result) to `H` (the
@@ -3552,9 +3565,7 @@ Bit-strings also support the following operations:
   `+0 <= L <= H < W+` are checked statically (where `W` is
   the length of the source bit-string). Note that both endpoints of
   the extraction are inclusive. The bounds are required to be
-  known-at-compile-time values so that the result width can be computed
-  at compile time. Slices are also l-values, which means that P4 supports
-  assigning to a slice: `e[H:L] = x`.
+  local compile-time known values so that the width of the result can be computed at compile time. Slices are also l-values, which means that P4 supports assigning to a slice: `e[H:L] = x`.
   The effect of this statement is to set bits `H` through `L` (inclusive of
   both) of `e` to the bit-pattern represented by `x`, and leaves all other bits
   of `e` unchanged.  A slice of an unsigned integer is an unsigned integer.
@@ -3623,7 +3634,7 @@ The `int<W>` datatype also support the following operations:
 
 * Arithmetic shift left and right denoted by `<<` and `>>`.
   The left operand is signed and the right operand must be either an
-  unsigned number of type `bit<S>` or a non-negative integer compile-time known value.
+  unsigned number of type `bit<S>` or a compile-time known value that is a non-negative integer.
   The result has the same type as the left operand.
   Shifting left produces the exact same bit pattern as a shift left
   of an unsigned value.  Shift left can thus overflow,
@@ -3635,7 +3646,7 @@ The `int<W>` datatype also support the following operations:
 ** all result bits are one when shifting a negative value right
 * Extraction of a set of contiguous bits, also known as a slice,
   denoted by `[H:L]`, where `H` and `L` must be expressions that evaluate to
-  non-negative compile-time known values, and `H >= L` must be true.
+  non-negative, local compile-time known values, and `H >= L` must be true.
   The types of `H` and `L` (which do not need to be identical)
   must be numeric (<<sec-numeric-values>>).
   The result is an unsigned bit-string of width `H - L + 1`, including the bits
@@ -3676,11 +3687,11 @@ expressions of type `int` must be compile-time known values.  The type
 * Truncating integer division between positive values, denoted by `/`.
 * Modulo between positive values, denoted by `%`.
 * Arithmetic shift left and right denoted by `<<` and `>>`. These operations produce an `int` result.
-  The right operand must be either an unsigned constant of type `bit<S>` or a non-negative integer compile-time known value.
+  The right operand must be either an unsigned value of type `bit<S>` or a compile-time known value that is a non-negative integer.
   The expression `a << b` is equal to latexmath:[a \times 2^b] while `a >> b`
   is equal to latexmath:[\lfloor{a / 2^b}\rfloor].
-* Bit slices, denoted by `[H:L]`, where `H` and `L` must be expressions that evaluate to
-  non-negative compile-time known values, and `H >= L` must be true.
+* Bit slices, denoted by `[H:L]`, where `H` and `L` must be expressions   that evaluate to
+  non-negative, local compile-time known values, and `H >= L` must be true.
   The types of `H` and `L` (which do not need to be identical)
   must be one of the following:
 +
@@ -3741,7 +3752,7 @@ result is taken from the left operand.
 
 The left operand of shifts can be any one out of unsigned bit-strings, signed bit-strings,
 and arbitrary-precision integers, and the right operand of shifts must be either
-an expression of type `bit<S>` or a non-negative integer compile-time known value.
+an expression of type `bit<S>` or a compile-time known value that is a non-negative integer.
 The result has the same type as the left operand.
 
 Shifts on signed and unsigned bit-strings deserve a special discussion
@@ -3813,8 +3824,7 @@ finding this information in a section dedicated to type `varbit`.
   inserts a variable-sized bit-string with a known dynamic width into
   the packet being constructed.
 
-Additionally, the size of a variable-length bit-string can be determined at
-compile-time (<<sec-minsizeinbits>>).
+Additionally, the maximum size of a variable-length bit-string can be determined at compile-time (<<sec-minsizeinbits>>).
 
 [#sec-casts]
 === Casts
@@ -3902,7 +3912,7 @@ the compiler will add implicit casts as follows:
 * `E.a pass:[++] 8w0` becomes `(bit<8>)E.a pass:[++] 8w0`
 
 The compiler also adds implicit casts when types of different
-expressions need to "match"; for example, as described in
+expressions need to `match`; for example, as described in Section
 <<sec-select>>, since select labels are compared against the selected
 expression, the compiler will insert implicit casts for the select
 labels when they have `int` types.  Similarly, when assigning a
@@ -3983,7 +3993,7 @@ tuple<bit<32>, bool> x = { 10, false };
 ----
 
 The fields of a tuple can be accessed using array index syntax `x[0]`,
-`x[1]`.  The array indexes *must* be compile-time constants, to enable
+`x[1]`.  The indexes *must* be local compile-time known values, to enable
 the type-checker to identify the field types statically.
 
 Tuples can be compared for equality using `==` and `!=`; two tuples are
@@ -4444,10 +4454,8 @@ expressions are legal:
 
 * `hs[index]`: produces a reference to the header at the
   specified position within the stack; if `hs` is an l-value,
-  the result is also an l-value. The header may be invalid. Some implementations
-  may impose the constraint that the index expression evaluates to a
-  value that is known at compile time. A P4 compiler must give an error
-  if an index value that is a compile-time constant is out of range.
+  the result is also an l-value. The header may be invalid. Some implementations may impose the constraint that the index expression must be a compile-time known value.
+  A P4 compiler must give an error if an index that is a compile-time known value is out of range.
 +
 Accessing a header stack `hs` with an index less than `0` or
 greater than or equal to `hs.size` results in an undefined value.  See <<sec-uninitialized-values-and-writing-invalid-headers>> for more
@@ -4456,7 +4464,7 @@ details.
 The `index` is an expression that must be of numeric types (<<sec-numeric-values>>).
 
 * `hs.size`: produces a 32-bit unsigned integer that returns the
-  size of the header stack (a compile-time constant).
+  size of the header stack (a local compile-time known value).
 
 * assignment from a header stack `hs` into another stack requires
   the stacks to have the same types and sizes. All components of `hs`
@@ -4489,17 +4497,16 @@ Finally, P4 offers the following computations that can be used to
 manipulate the elements at the front and back of the stack:
 
 * `hs.push_front(int count)`: shifts `hs` "right" by `count`. The
-  first `count` elements become invalid. The last `count`
-  elements in the stack are discarded. The `hs.nextIndex` counter
-  is incremented by `count`. The `count` argument must be a
-  positive integer that is a compile-time known value. The return type
-  is `void`.
+  first `count` elements become invalid. The last `count` elements in
+  the stack are discarded. The `hs.nextIndex` counter is incremented
+  by `count`. The `count` argument must be a compile-time known value
+  that is a positive integer. The return type is `void`.
 
 * `hs.pop_front(int count)`: shifts `hs` "left" by `count`
   (i.e., element with index `count` is copied in stack at index `0`).
   The last `count` elements become invalid. The `hs.nextIndex`
   counter is decremented by `count`. The `count` argument must
-  be a positive integer that is a compile-time known value. The return
+  be a compile-time known value that is a positive integer. The return
   type is `void`.
 
 The following pseudocode defines the behavior of `push_front` and `pop_front`:
@@ -4536,8 +4543,7 @@ void pop_front(int count) {
 }
 ----
 
-Similar to structs and headers, the size of a header stack can be determined at
-compile-time (<<sec-minsizeinbits>>).
+Similar to structs and headers, the size of a header stack is a compile-time known value (Section <<#sec-minsizeinbits>>).
 
 Two header stacks can be compared for equality (`==`) or inequality (`!=`)
 only if they have the same element type and the same length.  Two
@@ -4796,8 +4802,7 @@ parser Tcp_option_parser(packet_in b, out Tcp_option_stack vec) {
 }
 ----
 
-Similar to headers, the size of a header union can be determined at
-compile-time (<<sec-minsizeinbits>>).
+Similar to headers, the size of a header union is a local compile-time known value (Section <<#sec-minsizeinbits>>).
 
 The expression `+{#}+` represents an invalid header union of some type,
 but it can be any header or header union type.  A P4 compiler may require an
@@ -4984,21 +4989,19 @@ limitation, such values are currently of limited utility.
 [#sec-uninitialized-values-and-writing-invalid-headers]
 === Reading uninitialized values and writing fields of invalid headers
 
-As mentioned in <<sec-expr-hs>>, any reference to an element of
-a header stack `hs[index]` where `index` is a compile-time constant
-expression must give an error at compile time if the value of the
-index is out of range.  That section also defines the run time
-behavior of the expressions `hs.next` and `hs.last`, and the behaviors
-specified there take precedence over anything in this section for
-those expressions.
+As mentioned in Section <<#sec-expr-hs>>, any reference to an element of
+a header stack `hs[index]` where `index` is a compile-time known value
+must give an error at compile time if the value of the index is out of
+range.  That section also defines the run time behavior of the
+expressions `hs.next` and `hs.last`, and the behaviors specified there
+take precedence over anything in this section for those expressions.
 
-All mentions of header stack elements in this section only apply
-for expressions `hs[index]` where `index` is a runtime variable
-expression, i.e. not a compile-time constant value.
-A P4 implementation is allowed not to support `hs[index]` where
-`index` is a runtime variable expression, but if it does support
-these expressions, the implementation should conform to the
-behaviors specified in this section.
+All mentions of header stack elements in this section only apply for
+expressions `hs[index]` where `index` is not a compile-time known
+value.  A P4 implementation may elect not to support expressions of
+the form `hs[index]` where `index` is not a compile-time known
+value. However, it does support such expressions, the implementation
+should conform to the behaviors specified in this section.
 
 The result of reading a value in any of the situations below is that
 some unspecified value will be used for that field.
@@ -5150,7 +5153,8 @@ T t2 = { s = ... }; // error: no initializer specified for fields n0 and n1
 tuple<N0, N1> p = { ... }; // initialize p with default value { 0, N1.A }
 T t3 = { ..., n0 = 2}; // error: ... must be last
 H h1 = ...;   // initialize h1 with a header that is invalid
-H h2 = { f2=5, ... };   // initialize h2 with a header that is valid, field f1 0, field f2 5
+H h2 = { f2=5, ... };   // initialize h2 with a header that is valid, field f1 0,
+                        // field f2 5
 H h3 = { ... };  // initialize h3 with a header that is valid, field f1 0, field f2 0
 ----
 
@@ -5158,14 +5162,17 @@ H h3 = { ... };  // initialize h3 with a header that is valid, field f1 0, field
 == Compile-time size determination
 
 The method calls `minSizeInBits`, `minSizeInBytes`, `maxSizeInBits`,
-and `maxSizeInBytes` can be applied to some expressions.  Each of
-these method calls evaluate to compile-time known values that return
-the minimum size in bits required to store the expression (thus the
-result type of these methods has type `int`).  None of these methods
-evaluates the expression itself.  In consequence, the expression may
-be invalid (e.g., an out-of-bounds header stack access).
+and `maxSizeInBytes` can be applied to certain expressions. These
+method calls return the minimum (or maximum) size in bits (or bytes) required to
+store the expression. Thus, the result type of these methods has type
+`int`. Except in certain situations involving type variables,
+discussed below, these method calls produce local compile-time known
+values; otherwise they produce compile-time known values. None of
+these methods evaluate the expression that is the receiver of the
+method call, so it may be invalid (e.g., an out-of-bounds header stack
+access).
 
-The method `minSizeInBytes` always returns the result of
+The method `minSizeInBytes` returns the result of
 `minSizeInBits` rounded up to the next whole number of bytes.
 In other words, for any expression `e`,
 `e.minSizeInBytes()` is equal to `(e.minSizeInBits() + 7) >> 3`.
@@ -5222,7 +5229,9 @@ These methods are defined for:
 * for a type that does contain `varbit` fields, `maxSizeInBits` is the worst-case size
   of the serialized representation of the data and `minSizeInBits` is the "best" case.
 
-Every other case is undefined and will produce a compile-time error.
+Every other case is undefined and will produce a compile-time
+error. In particular, cases involving type variables produce a
+compile-time error.
 
 [#sec-functions]
 == Function declarations
@@ -5280,7 +5289,7 @@ struct Version {
 const Version version = { 32w0, 32w0 };
 ----
 
-The `initializer` expression must be a compile-time known value.
+The `initializer` expression must be a local compile-time known value.
 
 [#sec-variables]
 === Variables
@@ -5339,7 +5348,7 @@ instantiation
 ----
 
 An instantiation is written as a constructor invocation followed by a name.
-Instantiations are always executed at compilation time (<<sec-ct-constants>>).
+Instantiations are always executed at compilation time (Section <<#sec-compile-time-known>>).
 The effect is to allocate an object with the specified name,
 and to bind it to the result of the constructor invocation.
 Note that instantiation arguments can be specified by name.
@@ -5489,10 +5498,10 @@ include::grammar.adoc[tag=emptyStatement]
 [#sec-block-stmt]
 === Block statement
 
-A block statement is denoted by curly braces. It contains a
-sequence of statements and declarations, which are executed
-sequentially. The variables and constants within a
-block statement are only visible within the block.
+A block statement is denoted by curly braces. It contains a sequence
+of statements and declarations, which are executed sequentially. The
+declarations (e.g., variables and constants) within a block statement
+are only visible within the block.
 
 [source,bison]
 ----
@@ -5975,9 +5984,9 @@ This constitutes an important difference between `select`
 expressions and the `switch` statements found in many programming languages since the keysets of
 a `select` expression may "overlap".
 
-The typical way to use a `select` expression is to compare
-the value of a recently-extracted header field against a set of
-constant values, as in the following example:
+The typical way to use a `select` expression is to compare the value
+of a recently-extracted header field against a set of values, as in
+the following example:
 
 [source,p4]
 ----
@@ -6716,7 +6725,7 @@ In addition, the tables may optionally define the following properties,
 
 The compiler must set the `default_action` to `NoAction` (and also
 insert it into the list of `actions`) for tables that do not define
-the `default_action` property`.  Hence, all tables can be thought of
+the `default_action` property.  Hence, all tables can be thought of
 as having a `default_action` property, either implicitly or
 explicitly.
 
@@ -6724,8 +6733,8 @@ In addition, tables may contain architecture-specific properties (see
 <<sec-additional-table-properties>>).
 
 A property marked as `const` cannot be changed dynamically by the
-control plane. The `key`, `actions`, and `size` properties are always
-constant, so the `const` keyword is not needed for these.
+control plane. The `key`, `actions`, and `size` properties cannot be
+modified so the `const` keyword is not needed for these.
 
 [#sec-table-props]
 ==== Table properties
@@ -6733,11 +6742,12 @@ constant, so the `const` keyword is not needed for these.
 [#sec-table-keys]
 ===== Keys
 
-The `key` is a table property which specifies the data-plane
-values that should be used to look up an entry. A key is a list of
-pairs of the form `(e : m)`, where `e` is an expression that describes
-the data to be matched in the table, and `m` is a `match_kind`
-constant that describes the algorithm used to perform the lookup (see <<sec-match-kind-type>>).
+The `key` is a table property which specifies the data-plane values
+that should be used to look up an entry. A key is a list of pairs of
+the form `(e : m)`, where `e` is an expression that describes the data
+to be matched in the table, and `m` is a `match_kind` that describes
+the algorithm used to perform the lookup (see Section
+<<#sec-match-kind-type>>).
 
 [source,bison]
 ----
@@ -6759,7 +6769,7 @@ table Fwd {
 ----
 
 Here the key comprises two fields from the `ipv4header`
-header: `dstAddress` and `version`. The `match_kind` constants
+header: `dstAddress` and `version`. The `match_kind` elements
 serve three purposes:
 
 - They specify the algorithm used to match data-plane values against
@@ -7309,10 +7319,9 @@ because of the `@noWarn("duplicate_priorities")` annotation.
 ===== Size
 
 The `size` is an optional property of a table.  When present, its
-value must always be an integer compile-time known value.  It is specified
-in units of number of table entries.
+value must always be a compile-time known value that is an integer. The `size` property is specified in units of number of table entries.
 
-If a table has a `size` value specified for it with value `N`, it is
+If a table is specified with a `size` property of value `N`, it is
 recommended that a compiler should choose a data plane implementation
 that is capable of storing `N` table entries.  This does not guarantee
 that an _arbitrary_ set of `N` entries can always be inserted in such
@@ -7713,7 +7722,8 @@ control Callee<T>(/* parameters omitted */) { /* body omitted */ }
 
 control Caller(/* parameters omitted */)(/* parameters omitted */) {
     apply {
-        Callee<bit<32>>.apply(/* arguments omitted */); // Callee<bit<32>> is treated as an instance
+        // Callee<bit<32>> is treated as an instance
+        Callee<bit<32>>.apply(/* arguments omitted */);
     }
 }
 ----
@@ -8017,33 +8027,55 @@ The evaluation of a P4 program is done in two stages:
   executed to completion, in isolation, when it receives control from the
   architecture
 
-[#sec-ct-constants]
-=== Compile-time known values
+[#sec-compile-time-known]
+=== Compile-time known and local compile-time known values
 
-The following are compile-time known values:
+Certain expressions in a P4 program have the property that their value
+can be determined at compile time. Moreover, for some of these
+expressions, their value can be determined only using information in
+the current scope. We call these _compile-time known values_ and
+_local compile-time known values_ respectively.
+
+The following are local compile-time known values:
 
 - Integer literals, Boolean literals, and string literals.
-- Identifiers declared in an `error`, `enum`, or `match_kind`
-  declaration.
+- Identifiers declared as constants using the `const` keyword.
+- Identifiers declared in an `error`, `enum`, or `match_kind` declaration.
 - The `default` identifier.
 - The `size` field of a value with type header stack.
 - The `_` identifier when used as a `select` expression label
-- The expression `+{#}+` representing an invalid header or header union
-  value.
-- Identifiers that represent declared types, actions, tables, parsers,
-  controls, or packages.
+- The expression `{#}` representing an invalid header or header union value.
+- Instances constructed by instance declarations (Section [#sec-instantiations]) and constructor invocations.
+- Identifiers that represent declared types, actions, functions, tables, parsers, controls, or packages.
+- Tuple expression where all components are local compile-time known values.
+- Structure-valued expressions, where all fields are local compile-time known values.
+- Expressions evaluating to a list type, where all elements are local compile-time known values.
+- Legal casts applied to local compile-time known values.
+- The following expressions (`+`, `-`, `|+|`, `|-|`, `*`, `/ `, `%`, `!`, `&`, `|`, `^`, `&&`, `||`, `<< `, `>>`, `~`, `/`, `>`, `<`, `==`, `!=`, `<=`, `>=`, `++`, `[:]`, `?:`) when their operands are all local compile-time known values.
+- Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`, `e.maxSizeInBits()` and `e.maxSizeInBytes()` where the type of `e` is not generic.
+
+The following are compile-time known values:
+
+- All local compile-time known values.
+- Constructor parameters (i.e., the declared parameters for a `parser`, `control`, etc.)
 - Tuple expression where all components are compile-time known values.
-- Structure-valued expressions, where all fields are compile-time
-  known values.
-- Expressions evaluating to a list type, where all elements are
-  compile-time known values.
-- Instances constructed by instance declarations (<<sec-instantiations>>) and constructor invocations.
-- A legal cast applied to a compile-time known value
-- The following expressions (`pass:[+]`, `-`, `*`, `/`, `%`, `!`, `&`, `|`, `&&`, `||`, `<<`, `>>`, `~`, `>`, `<`, `==`, `!=`, `+<=+`, `>=`, `pass:[++]`, `[:]`, `?:`)
-  when their operands are all compile-time known values.
-- Identifiers declared as constants using the `const` keyword.
-- Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`,
-  `e.maxSizeInBits()` and `e.maxSizeInBytes()`
+- Expressions evaluating to a list type, where all elements are compile-time known values.
+- Structure-valued expressions, where all fields are compile-time known values.
+- Expressions evaluating to a list type, where all elements are compile-time known values.
+- Legal casts applied to compile-time known values.
+- The following expressions (`+`, `-`, `|+|`, `|-|`, `*`, `/ `, `%`, `cast`, `!`, `&`, `|`, `^`, `&&`, `||`, `<< `, `>> `, `~`, `/`, `>`, `<`, `==`, `!=`, `<=`, `>=`, `++`, `[:]`, `?:`) when their operands are all compile-time known values.
+- Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`, `e.maxSizeInBits()` and `e.maxSizeInBytes()` where the the type of `e` is generic.
+
+Intuitively, the main difference between _compile-time known values_
+and _local compile-time known values_ is that the former also contains
+constructor parameters. The distinction is important when it comes to
+defining the meaning of features like types. For example, in the type
+`bit<e>`, the expression `e` must be a local compile-time known
+value. Suppose instead that `e` were a constructor parameter---i.e.,
+merely a compile-time known value. In this situation, it would be
+impossible to resolve `bit<e>` to a concrete type using purely local
+information---we would have to wait until the constructor was
+instantiated and the value of `e` known.
 
 [#sec-ct-eval]
 === Compile-time Evaluation
@@ -8518,7 +8550,7 @@ extern bool static_assert(bool check);
 ----
 
 These functions both return boolean values.  Since the parameters are
-directionless, these functions require compile-time constant values as
+directionless, these functions require compile-time known values as
 arguments, thus they can be used to enforce compile-time invariants.
 Since P4 does not allow statements at the program top-level (outside
 of apply blocks), these functions can be used at the top-level by
@@ -8628,10 +8660,10 @@ metadata, consisting of expression lists or key-value lists but not both. An
 a key and a value `expression`. Note the syntax for `expression` is rich, see
 <<sec-grammar>> for details.
 
-All ``expression``s within a `structuredAnnotationBody` must be compile-time known
-values, either literals or expressions requiring compile-time evaluation, with a
-result type that is one of: string literals, arbitrary-precision integer, or
-boolean. Structured ``expression``s (e.g. an `expression` containing an
+All `expression`s within a `structuredAnnotationBody` must be compile-time known
+values with a result type that is either: `string`, `int`, or `bool`.
+
+In particular, structured `expression`s (e.g. an `expression` containing an
 `expressionList`, a `kvList`, etc.) are not allowed. Note that P4Runtime
 information (P4Info) may stipulate additional restrictions. For example, an
 integer expression might be limited to 64-bit values.
@@ -8946,14 +8978,22 @@ The P4 compiler should provide:
 
 - Errors when annotations are used incorrectly (e.g., an annotation
   expecting a parameter but used without arguments, or with arguments
-  of the wrong type
+  of the wrong type)
 - Warnings for unknown annotations.
 
 [appendix]
 [#sec-revision-history]
 == Revision History
 
-=== Summary of changes made in version 1.2.4
+===  Summary of changes made in unreleased version
+
+=== Summary of changes made in version 1.2.5, released October 11, 2024
+
+* Improved type nesting rules (Section <<#sec-type-nesting>>).
+* Clarified that directionless extern parameters are passed by reference.
+* Introduced distinction between local compile-time known and compile-time known values (Section <<#sec-compile-time-known>>).
+
+=== Summary of changes made in version 1.2.4,released May 15, 2023
 
 * Added header stack expressions (<<sec-hs-init>>).
 * Allow casts from a type to itself (<<sec-casts>>).
@@ -9003,7 +9043,7 @@ The P4 compiler should provide:
 * Added `match_kind` as a base type (<<sec-match-kind-type>>).
 * Removed structure initializers as they are subsumed by structure-valued expressions (<<sec-structure-expressions>>).
 * Specified operations on values typed as type variables (<<sec-type-variable-operations>>).
-* Clarified semantics of compile-time known values (<<sec-ct-constants>>).
+* Clarified semantics of compile-time known values (<<sec-compile-time-known>>).
 * Clarified semantics of directionless parameters (<<sec-calling-convention>>).
 * Clarified semantics of arbitrary precision integers (<<sec-arbitrary-precision-integers>>).
 * Clarified semantics of bit slices, shifts, and concatenation (<<sec-bit-ops>>).

--- a/p4-spec-next/P4-16-spec.mdk
+++ b/p4-spec-next/P4-16-spec.mdk
@@ -1,5 +1,5 @@
 Title : P4~16~ Language Specification
-Title Note: version 1.2.4
+Title Note: version 1.2.5
 Title Footer: &date;
 Author: The P4 Language Consortium
 Heading depth: 5
@@ -1296,13 +1296,13 @@ literal. Here are some examples of numeric literals:
 
 #### String literals { #sec-string-literals }
 
-String literals (string constants) are specified as an arbitrary
-sequence of 8-bit characters, enclosed within double quote characters `"`
-(ASCII code 34). Strings start with a double quote character
-and extend to the first double quote sign which is not immediately
-preceded by an odd number of backslash characters (ASCII code 92). P4
-does not make any validity checks on strings (i.e., it does not check
-that strings represent legal UTF-8 encodings).
+String literals are specified as an arbitrary sequence of 8-bit
+characters, enclosed within double quote characters `"` (ASCII code
+34). Strings start with a double quote character and extend to the
+first double quote sign which is not immediately preceded by an odd
+number of backslash characters (ASCII code 92). P4 does not make any
+validity checks on strings (i.e., it does not check that strings
+represent legal UTF-8 encodings).
 
 Since P4 does not provide any operations on strings,
 string literals are generally passed unchanged through the P4 compiler to
@@ -1506,7 +1506,7 @@ Each parameter may be labeled with a direction:
   - For anything other than an action, e.g. a control, parser, or
     function, a directionless parameter means that the value supplied
     as an argument in a call must be a compile-time known value
-    (see Section [#sec-ct-constants]).
+    (see Section [#sec-compile-time-known]).
   - For an action, a directionless parameter indicates that it is
     "action data".  See Section [#sec-actions] for the meaning of
     action data, but its meaning includes the following possibilities:
@@ -1516,6 +1516,8 @@ Each parameter may be labeled with a direction:
     - The parameter's value is provided by the control plane software
       when an entry is added to a table that uses that action.  See
       Section [#sec-actions].
+
+A directionless parameter of extern object type is passed by reference.
 
 Direction `out` parameters are always initialized at the beginning of
 execution of the portion of the program that has the `out` parameters,
@@ -1676,8 +1678,8 @@ directions:
 - All constructor parameters are evaluated at compilation-time, and in
   consequence they must all be directionless (they cannot be `in`,
   `out`, or `inout`); this applies to `package`, `control`, `parser`,
-  and `extern` objects. Values for these parameters must be specified
-  at compile-time, and must evaluate to compile-time known values.
+  and `extern` objects. Expressions for these parameters must be supplied
+  at compile-time, and they must evaluate to compile-time known values.
   See Section [#sec-parameterization] for further details.
 - For actions all directionless parameters must be at the end of the
   parameter list.  When an action appears in a `table`'s `actions`
@@ -1689,8 +1691,9 @@ directions:
   including values for the directionless parameters. The directionless
   parameters in this case behave like `in` parameters.
   See Section [#sec-invoke-actions] for further details.
-- Default parameter values are only allowed for 'in' or direction-less parameters;
-  these values must evaluate to compile-time constants.
+- Default expressions are only allowed for 'in' or direction-less
+  parameters, and the expressions supplied as defaults must be
+  compile-time known values.
 - If parameters with default values do not appear at the
   end of the list of parameters, invocations that use
   the default values must use named arguments, as in the following
@@ -1755,8 +1758,9 @@ control nothing(inout Empty h, inout Empty m) {
 parser parserProto<H, M>(packet_in p, out H h, inout M m);
 control controlProto<H, M>(inout H h, inout M m);
 
-package pack<HP, MP, HC, MC>(@optional parserProto<HP, MP> _parser,  // optional parameter
-                             controlProto<HC, MC> _control = nothing()); // default parameter value
+package pack<HP, MP, HC, MC>(
+    @optional parserProto<HP, MP> _parser,  // optional parameter
+    controlProto<HC, MC> _control = nothing()); // default parameter value
 
 pack() main;   // No value for _parser, _control is an instance of nothing()
 ~End P4Example
@@ -1821,12 +1825,12 @@ P4 supports the following built-in base types:
   restricted circumstances.
 - The `error` type, which is used to convey errors in a
   target-independent, compiler-managed way.
-- The `string` type, which can be used only for compile-time
-  constant string values.
+- The `string` type, which can be used with compile-time known
+  values of type string.
 - The `match_kind` type, which is used for describing the implementation of
   table lookups,
 - `bool`, which represents Boolean values
-- `int`, which represents arbitrary-sized constant integer values
+- `int`, which represents arbitrary-sized integer values
 - Bit-strings of fixed width, denoted by `bit<>`
 - Fixed-width signed integers represented using two's complement `int<>`
 - Bit-strings of dynamically-computed width with a fixed maximum width `varbit<>`
@@ -1844,14 +1848,14 @@ restricted places in P4 programs.
 ### The error type
 
 The error type contains opaque distinct values that can be used to signal
-errors. It is written as `error`. New constants of the error type
+errors. It is written as `error`. New elements of the error type
 are defined with the syntax:
 
 ~ Begin P4Grammar
 [INCLUDE=grammar.mdk:errorDeclaration]
 ~ End P4Grammar
 
-All `error` constants are inserted into the `error`
+All elements of the `error` type are inserted into the `error`
 namespace, irrespective of the place where an error is
 defined. `error` is similar to an enumeration (`enum`)
 type in other languages. A program can contain multiple `error` declarations, which
@@ -1859,7 +1863,7 @@ the compiler will merge together. It is an error to declare the same
 identifier multiple times. Expressions of type `error` are
 described in Section [#sec-error-exprs].
 
-For example, the following declaration creates two constants of `error`
+For example, the following declaration creates two elements of the `error`
 type (these errors are declared in the P4 core library):
 
 ~ Begin P4Example
@@ -1911,19 +1915,18 @@ The type `string` represents strings.  There are no operations on
 string values; one cannot declare variables with a `string` type.
 Parameters with type `string` can be only directionless (see Section
 [#sec-calling-convention]).  P4 does not support string manipulation
-in the dataplane; the `string` type is only allowed for denoting
-compile-time constant string values.  These may be useful, for
-example, a specific target architecture may support an extern function
-for logging with the following signature:
+in the dataplane; the `string` type is only allowed for describing
+compile-time known values (i.e., string literals, as discussed in
+Section [#sec-string-literals]). Even so, the string type is useful,
+for example, in giving the type signature for extern functions such as
+the following:
 
 ~ Begin P4Example
 extern void log(string message);
 ~ End P4Example
 
-The only strings that can appear in a P4 program are constant string
-literals, described in Section [#sec-string-literals].  For example,
-the following annotation indicates that a specific name should be used
-for a table when generating the control-plane API:
+As another example, the following annotation indicates that the specified
+name should be used for a given table in the generated control-plane API:
 
 ~ Begin P4Example
 @name("acl") table t1 { /* body omitted */ }
@@ -1968,7 +1971,7 @@ restrictions may include:
 - Alignment and padding constraints (e.g., arithmetic may only be
   supported on widths which are an integral number of bytes).
 - Constraints on some operands (e.g., some architectures may only
-  support multiplications with small constants, or shifts with small
+  support multiplications by small values, or shifts with small
   values).
 
 The documentation supplied with a target should clearly specify restrictions, and
@@ -1983,14 +1986,14 @@ behavior should match this specification.
 An unsigned integer (which we also call a "bit-string") has an
 arbitrary width, expressed in bits. A bit-string of width `W` is
 declared as: `bit<W>`. `W` must be an expression that evaluates to a
-compile-time known value (see Section [#sec-ct-constants]) that is a
+local compile-time known value (see Section [#sec-compile-time-known]) that is a
 non-negative integer.  When using an expression for
-the size, the expression must be parenthesized and compile-time known.
+the size, the expression must be parenthesized.
 Bitstrings with width 0 are
 allowed; they have no actual bits, and can only have the value 0.  See
 [#sec-uninitialized-values-and-writing-invalid-headers] for additional details.
 Note that `bit<W>` type refers to both cases of `bit<W>`
-and `bit<(expression)>` where the width is compile-time known.
+and `bit<(expression)>` where the width is a compile-time known value.
 
 ~ Begin P4Example
 const bit<32> x = 10;   // 32-bit constant with value 10.
@@ -2017,11 +2020,13 @@ described in Section [#sec-bit-ops].
 
 #### Signed Integers {#sec-signed-integers}
 
-Signed integers are represented using two's complement. An integer with `W`
-bits is declared as: `int<W>`. `W` must be an expression that evaluates to
-a compile-time known value that is a positive integer.
-Note that `int<W>` type refers to both cases of `int<W>`
-and `int<(expression)>` where the width is compile-time known.
+Signed integers are represented using two's complement. An integer
+with `W` bits is declared as: `int<W>`. `W` must be an expression that
+evaluates to a local compile-time known (see Section
+[#sec-compile-time-known]) value that is a non-negative integer.  Note
+that `int<W>` type refers to both cases of `int<W>` and
+`int<(expression)>` where the width is a local compile-time known
+value.
 
 Bits within an integer are numbered from `0` to `W-1`. Bit `0`
 is the least significant, and bit `W-1` is the sign bit.
@@ -2048,13 +2053,14 @@ values, P4 provides a special bit-string type whose size is set at
 runtime, called a `varbit`.
 
 The type `varbit<W>` denotes a bit-string with a width of at most `W`
-bits, where `W` must be a non-negative integer that is a compile-time
-known value. For example, the type `varbit<120>` denotes the type
-of bit-string values that may have between 0 and 120 bits. Most
-operations that are applicable to fixed-size bit-strings (unsigned
-numbers) *cannot* be performed on dynamically sized bit-strings.
-Note that `varbit<W>` type refers to both cases of `varbit<W>`
-and `varbit<(expression)>` where the width is compile-time known.
+bits, where `W` is a local compile-time known value (see Section
+[#sec-compile-time-known]) that is a non-negative integer.  For
+example, the type `varbit<120>` denotes the type of bit-string values
+that may have between 0 and 120 bits. Most operations that are
+applicable to fixed-size bit-strings (unsigned numbers) *cannot* be
+performed on dynamically sized bit-strings.  Note that `varbit<W>`
+type refers to both cases of `varbit<W>` and `varbit<(expression)>`
+where the width is a compile-time known value.
 
 P4 architectures may impose additional constraints on varbit types:
 for example, they may limit the maximum size, or they may require `varbit`
@@ -2095,13 +2101,13 @@ parameters.
 
 #### Integer literal types
 
-The types of integer literals (constants) are as follows:
+The types of integer literals are as follows:
 
-- A simple integer constant has type `int`.
-- A non-negative integer prefixed with an integer width `N` and the
-  character `w` has type `bit<N>`.
-- An integer prefixed with an integer width `N` and the character `s`
-  has type `int<N>`.
+- An integer with no type prefix has type `int`.
+- A non-negative integer prefixed with an integer width `W` and the
+  character `w` has type `bit<W>`.
+- An integer prefixed with an integer width `W` and the character `s`
+  has type `int<W>`.
 
 The table below shows several examples of integer literals and their
 types. For additional examples of literals see Section
@@ -2182,9 +2188,9 @@ enum Suits { Clubs, Diamonds, Hearths, Spades }
 ~ End P4Example
 
 introduces a new enumeration type, which contains four
-constants---e.g., `Suits.Clubs`. An `enum` declaration
+elements---e.g., `Suits.Clubs`. An `enum` declaration
 introduces a new identifier in the current scope for naming the
-created type along with its distinct constants.
+created type along with its distinct elements.
 The underlying representation of the `Suits` enum is not
 specified, so their "size" in bits is not specified (it is
 target-specific).
@@ -2195,8 +2201,8 @@ allowed to have fields with such `enum` types. This requires the programmer prov
 an associated integer value for each symbolic entry in the enumeration.
 The symbol `typeRef` in the grammar above must be one of the following types:
 
-- an unsigned integer, i.e. `bit<W>` for some compile-time known `W`.
-- a signed integer, i.e. `int<W>` for some compile-time known `W`.
+- an unsigned integer, i.e. `bit<W>` for some local compile-time known value `W`.
+- a signed integer, i.e. `int<W>` for some local compile-time known value `W`.
 - a type name declared via `typedef`, where the base type of that type is either
 one of the types listed above, or another `typedef` name that meets these conditions.
 For example, the declaration
@@ -2211,13 +2217,13 @@ enum bit<16> EtherType {
 }
 ~ End P4Example
 
-introduces a new enumeration type, which contains five constants---e.g.,
+introduces a new enumeration type, which contains five elements---e.g.,
 `EtherType.IPV4`.  This `enum` declaration specifies the fixed-width unsigned integer representation
 for each entry in the `enum` and provides an underlying type: `bit<16>`.
-This type of `enum` declaration can be thought of as declaring a new `bit<16>`
+This kind of `enum` declaration can be thought of as declaring a new `bit<16>`
 type, where variables or fields of this type are expected to be unsigned 16-bit
 integer values, and the mapping of symbolic to numeric values defined by the
-`enum` are effectively constants defined as a part of this type.  In this way,
+`enum` are also defined as a part of this declaration.  In this way,
 an `enum` with an underlying type can be thought of as being a type derived
 from the underlying type carrying equality, assignment, and casts to/from the
 underlying type.
@@ -2319,14 +2325,13 @@ header ipv6_t {
 }
 ~ End P4Example
 
-Headers that do not contain any `varbit` field are "fixed
-size." Headers containing `varbit` fields have "variable
-size." The size (in bits) of a fixed-size header is a constant, and it
-is simply the sum of the sizes of all component fields (without
-counting the validity bit). There is no padding or alignment of the
-header fields. Targets may impose additional constraints on
-header types---e.g., restricting headers to sizes that are an integer
-number of bytes.
+Headers that do not contain any `varbit` field are "fixed size."
+Headers containing `varbit` fields have "variable size." The size (in
+bits) of a fixed-size header is simply the sum of the sizes of all
+component fields (without counting the validity bit). There is no
+padding or alignment of the header fields. Targets may impose
+additional constraints on header types---e.g., restricting headers to
+sizes that are an integer number of bytes.
 
 For example, the following declaration describes a typical Ethernet
 header:
@@ -2389,12 +2394,13 @@ defined as:
 [INCLUDE=grammar.mdk:headerStackType]
 ~ End P4Grammar
 
-where `typeName` is the name of a header or header union type. For a header stack `hs[n]`,
-the term `n` is the maximum defined size, and must be
-a positive integer that is a compile-time known value. Nested header
-stacks are not supported. At runtime a stack contains `n` values
-with type `typeName`, only some of which may be valid. Expressions
-on header stacks are discussed in Section [#sec-expr-hs].
+where `typeName` is the name of a header or header union type. For a
+header stack `hs[n]`, the term `n` is the maximum defined size, and
+must be a local compile-time known value that is a positive
+integer. Nested header stacks are not supported. At runtime a stack
+contains `n` values with type `typeName`, only some of which may be
+valid. Expressions on header stacks are discussed in Section
+[#sec-expr-hs].
 
 For example, the following declarations,
 
@@ -2511,27 +2517,27 @@ header unions, structs, tuples, and lists.  Note that `int` by itself
 arbitrary-precision integer, without a width specified.
 
 |--------------------|------------------------------------------------|||||
-|                    | Container type                                 |||||
+|                    | Container kind                                 |||||
 |                    |-----------|--------------|-----------------|------|--------------|
 | Element type       | header    | header_union | struct or tuple | list | header stack |
 +:-------------------+:----------+:-------------+:----------------+:-----+:-------------+
-| `bit<W>`       | allowed   | error   |  allowed | allowed | error |
-| `int<W>`       | allowed   | error   |  allowed | allowed | error |
-| `varbit<W>`    | allowed   | error   |  allowed | allowed | error |
-| `int`          | error     | error   |  error   | allowed | error |
-| `void`         | error     | error   |  error   | error   | error |
-| `string`       | error     | error   |  error   | allowed | error |
-| `error`        | error     | error   |  allowed | allowed | error |
-| `match_kind`   | error     | error   |  error   | allowed | error |
-| `bool`         | allowed   | error   |  allowed | allowed | error |
-| `enum`         | allowed[^enum_header]     | error   |  allowed | allowed | error |
-| `header`       | error     | allowed |  allowed | allowed | allowed |
-| header stack   | error     | error   |  allowed | allowed | error |
-| `header_union` | error     | error   |  allowed | allowed | allowed |
-| `struct`       | allowed[^struct_header]   | error   |  allowed | allowed | error |
-| `tuple`        | error     | error   |  allowed | allowed | error |
-| `list`         | error     | error   |  error   | allowed | error |
-|----------------|-----------|---------|----------|---------|-------|
+| `bit<W>`           | allowed   | error   |  allowed | allowed | error |
+| `int<W>`           | allowed   | error   |  allowed | allowed | error |
+| `varbit<W>`        | allowed   | error   |  allowed | allowed | error |
+| `int`              | error     | error   |  error   | allowed | error |
+| `void`             | error     | error   |  error   | error   | error |
+| `string`           | error     | error   |  error   | allowed | error |
+| `error`            | error     | error   |  allowed | allowed | error |
+| `match_kind`       | error     | error   |  error   | allowed | error |
+| `bool`             | allowed   | error   |  allowed | allowed | error |
+| enumeration types  | allowed[^enum_header]     | error   |  allowed | allowed | error |
+| header types       | error     | allowed |  allowed | allowed | allowed |
+| header stacks      | error     | error   |  allowed | allowed | error |
+| header unions      | error     | error   |  allowed | allowed | allowed |
+| struct types       | allowed[^struct_header]   | error   |  allowed | allowed | error |
+| tuple types        | error     | error   |  allowed | allowed | error |
+| list types         | error     | error   |  error   | allowed | error |
+|--------------------|-----------|---------|----------|---------|-------|
 
 [^enum_header]: an `enum` type used as a field in a `header` must specify a
     underlying type and representation for `enum` elements.
@@ -2557,26 +2563,32 @@ The table below lists all types that may appear as base types in a
 `typedef` or `type` declaration.
 
 
-|------------------|--------------------|-----------------|
-| Base type B      | `typedef B <name>` | `type B <name>` |
-+:-----------------+:-------------------+:----------------+
-| `bit<W>`         | allowed            | allowed         |
-| `int<W>`         | allowed            | allowed         |
-| `varbit<W>`      | allowed            | error           |
-| `int`            | allowed            | error           |
-| `void`           | error              | error           |
-| `error`          | allowed            | error           |
-| `match_kind`     | error              | error           |
-| `bool`           | allowed            | allowed         |
-| `enum`           | allowed            | error           |
-| `header`         | allowed            | error           |
-| header stack     | allowed            | error           |
-| `header_union`   | allowed            | error           |
-| `struct`         | allowed            | error           |
-| `tuple`          | allowed            | error           |
-| a `typedef` name | allowed            | allowed[^type_allowed] |
-| a `type` name    | allowed            | allowed         |
-|------------------|--------------------|-----------------|
+|-------------------|--------------------|-----------------|
+| Base type B       | `typedef B <name>` | `type B <name>` |
++:------------------+:-------------------+:----------------+
+| `bit<W>`          | allowed            | allowed         |
+| `int<W>`          | allowed            | allowed         |
+| `varbit<W>`       | allowed            | error           |
+| `int`             | allowed            | error           |
+| `void`            | error              | error           |
+| `string`          | allowed            | error           |
+| `error`           | allowed            | error           |
+| `match_kind`      | error              | error           |
+| `bool`            | allowed            | allowed         |
+| enumeration types | allowed            | error           |
+| header types      | allowed            | error           |
+| header stacks     | allowed            | error           |
+| header unions     | allowed            | error           |
+| struct types      | allowed            | error           |
+| tuple types       | allowed            | error           |
+| list types        | allowed            | error           |
+| a `typedef` name  | allowed            | allowed[^type_allowed] |
+| a `type` name     | allowed            | allowed         |
+|-------------------|--------------------|-----------------|
+
+Rationale: So far, no clear motivation for allowing `typedef` for `void`
+and `match_kind` was presented. Therefore, to be on the safe side this
+is disallowed.
 
 [^type_allowed]: `type B <name>` is allowed for a type name `B`
     defined via `typedef X B` if `type X <name>` is allowed.
@@ -3340,6 +3352,7 @@ const bool same = exact == fuzzy;  // always 'false'
 ## Expressions on Booleans { #sec-bool-exprs }
 
 The following operations are provided on Boolean expressions:
+
 - "And", denoted by `&&`
 - "Or", denoted by `||`
 - Negation, denoted by `!`
@@ -3453,8 +3466,8 @@ to bit-strings of the same width:
 
 Bit-strings also support the following operations:
 
-- Logical shift left and right by a (not-necessarily-known-at-compile-time)
-  non-negative integer value, denoted by `<<` and `>>` respectively.
+- Logical shift left and right by a non-negative integer value (which need not be
+  a compile-time known value), denoted by `<<` and `>>` respectively.
   In a shift, the left operand is unsigned, and right operand must be either an
   expression of type `bit<S>` or a non-negative integer value that is known at
   compile time.  The result has the same type as the left operand.
@@ -3462,7 +3475,7 @@ Bit-strings also support the following operations:
   produces a result where all bits are zero.
 - Extraction of a set of contiguous bits, also known as a slice,
   denoted by `[H:L]`, where `H` and `L` must be expressions that evaluate to
-  non-negative compile-time known values, and `H >= L`. The types of `H` and `L`
+  non-negative, local compile-time known values, and `H >= L`. The types of `H` and `L`
   (which do not need to be identical) must be numeric (Section [#sec-numeric-values]).
   The result is a bit-string of width `H - L + 1`, including the bits numbered
   from `L` (which becomes the least significant bit of the result) to `H` (the
@@ -3470,7 +3483,7 @@ Bit-strings also support the following operations:
   `0 <= L <= H < W` are checked statically (where `W` is
   the length of the source bit-string). Note that both endpoints of
   the extraction are inclusive. The bounds are required to be
-  known-at-compile-time values so that the result width can be computed
+  local compile-time known values so that the width of the result can be computed
   at compile time. Slices are also l-values, which means that P4 supports
   assigning to a slice: ` e[H:L] = x `.
   The effect of this statement is to set bits `H` through `L` (inclusive of
@@ -3540,7 +3553,7 @@ The `int<W>` datatype also support the following operations:
 
 - Arithmetic shift left and right denoted by `<<` and `>>`.
   The left operand is signed and the right operand must be either an
-  unsigned number of type `bit<S>` or a non-negative integer compile-time known value.
+  unsigned number of type `bit<S>` or a compile-time known value that is a non-negative integer.
   The result has the same type as the left operand.
   Shifting left produces the exact same bit pattern as a shift left
   of an unsigned value.  Shift left can thus overflow,
@@ -3552,7 +3565,7 @@ The `int<W>` datatype also support the following operations:
   - all result bits are one when shifting a negative value right
 - Extraction of a set of contiguous bits, also known as a slice,
   denoted by `[H:L]`, where `H` and `L` must be expressions that evaluate to
-  non-negative compile-time known values, and `H >= L` must be true.
+  non-negative, local compile-time known values, and `H >= L` must be true.
   The types of `H` and `L` (which do not need to be identical)
   must be numeric (Section [#sec-numeric-values]).
   The result is an unsigned bit-string of width `H - L + 1`, including the bits
@@ -3592,11 +3605,11 @@ expressions of type `int` must be compile-time known values.  The type
 - Truncating integer division between positive values, denoted by `/`.
 - Modulo between positive values, denoted by `%`.
 - Arithmetic shift left and right denoted by `<<` and `>>`. These operations produce an `int` result.
-  The right operand must be either an unsigned constant of type `bit<S>` or a non-negative integer compile-time known value.
+  The right operand must be either an unsigned value of type `bit<S>` or a compile-time known value that is a non-negative integer.
   The expression `a << b` is equal to $a \times 2^b$ while `a >> b`
   is equal to $\lfloor{a / 2^b}\rfloor$.
 - Bit slices, denoted by `[H:L]`, where `H` and `L` must be expressions that evaluate to
-  non-negative compile-time known values, and `H >= L` must be true.
+  non-negative, local compile-time known values, and `H >= L` must be true.
   The types of `H` and `L` (which do not need to be identical)
   must be one of the following:
 
@@ -3654,7 +3667,7 @@ result is taken from the left operand.
 
 The left operand of shifts can be any one out of unsigned bit-strings, signed bit-strings,
 and arbitrary-precision integers, and the right operand of shifts must be either
-an expression of type `bit<S>` or a non-negative integer compile-time known value.
+an expression of type `bit<S>` or a compile-time known value that is a non-negative integer.
 The result has the same type as the left operand.
 
 Shifts on signed and unsigned bit-strings deserve a special discussion
@@ -3724,7 +3737,7 @@ finding this information in a section dedicated to type `varbit`.
   inserts a variable-sized bit-string with a known dynamic width into
   the packet being constructed.
 
-Additionally, the size of a variable-length bit-string can be determined at
+Additionally, the maximum size of a variable-length bit-string can be determined at
 compile-time (Section [#sec-minsizeinbits]).
 
 ## Casts { #sec-casts }
@@ -3770,7 +3783,7 @@ The following casts are legal in P4:
 - casts of a tuple expression to a header stack type
 - casts of an invalid expression `{#}` to a header or a header union type
 - casts where the destination type is the same as the source type
-  if the destination type appears in this list (this excludes 
+  if the destination type appears in this list (this excludes
   e.g., parsers or externs).
 
 ### Implicit casts { sec-implicit-casts }
@@ -3810,7 +3823,7 @@ the compiler will add implicit casts as follows:
 - `E.a ++ 8w0` becomes `(bit<8>)E.a ++ 8w0`
 
 The compiler also adds implicit casts when types of different
-expressions need to ``match''; for example, as described in Section
+expressions need to `match`; for example, as described in Section
 [#sec-select], since select labels are compared against the selected
 expression, the compiler will insert implicit casts for the select
 labels when they have `int` types.  Similarly, when assigning a
@@ -3868,7 +3881,7 @@ tuple<bit<32>, bool> x = { 10, false };
 ~ End P4Example
 
 The fields of a tuple can be accessed using array index syntax `x[0]`,
-`x[1]`.  The array indexes *must* be compile-time constants, to enable
+`x[1]`.  The indexes *must* be local compile-time known values, to enable
 the type-checker to identify the field types statically.
 
 Tuples can be compared for equality using `==` and `!=`; two tuples are
@@ -4299,9 +4312,8 @@ expressions are legal:
 - `hs[index]`: produces a reference to the header at the
   specified position within the stack; if `hs` is an l-value,
   the result is also an l-value. The header may be invalid. Some implementations
-  may impose the constraint that the index expression evaluates to a
-  value that is known at compile time. A P4 compiler must give an error
-  if an index value that is a compile-time constant is out of range.
+  may impose the constraint that the index expression must be a compile-time known value.
+  A P4 compiler must give an error if an index that is a compile-time known value is out of range.
 
   Accessing a header stack ``hs`` with an index less than `0` or
   greater than or equal to `hs.size` results in an undefined value.  See Section
@@ -4311,7 +4323,7 @@ expressions are legal:
   The `index` is an expression that must be of numeric types (Section [#sec-numeric-values]).
 
 - `hs.size`: produces a 32-bit unsigned integer that returns the
-  size of the header stack (a compile-time constant).
+  size of the header stack (a local compile-time known value).
 
 - assignment from a header stack `hs` into another stack requires
   the stacks to have the same types and sizes. All components of `hs`
@@ -4344,17 +4356,16 @@ Finally, P4 offers the following computations that can be used to
 manipulate the elements at the front and back of the stack:
 
 - `hs.push_front(int count)`: shifts `hs` "right" by `count`. The
-  first `count` elements become invalid. The last `count`
-  elements in the stack are discarded. The `hs.nextIndex` counter
-  is incremented by `count`. The `count` argument must be a
-  positive integer that is a compile-time known value. The return type
-  is `void`.
+  first `count` elements become invalid. The last `count` elements in
+  the stack are discarded. The `hs.nextIndex` counter is incremented
+  by `count`. The `count` argument must be a compile-time known value
+  that is a positive integer. The return type is `void`.
 
 - `hs.pop_front(int count)`: shifts `hs` "left" by `count`
   (i.e., element with index `count` is copied in stack at index `0`).
   The last `count` elements become invalid. The `hs.nextIndex`
   counter is decremented by `count`. The `count` argument must
-  be a positive integer that is a compile-time known value. The return
+  be a compile-time known value that is a positive integer. The return
   type is `void`.
 
 The following pseudocode defines the behavior of `push_front` and `pop_front`:
@@ -4390,8 +4401,8 @@ void pop_front(int count) {
 }
 ~ End P4Pseudo
 
-Similar to structs and headers, the size of a header stack can be determined at
-compile-time (Section [#sec-minsizeinbits]).
+Similar to structs and headers, the size of a header stack is a compile-time known value
+(Section [#sec-minsizeinbits]).
 
 Two header stacks can be compared for equality (`==`) or inequality (`!=`)
 only if they have the same element type and the same length.  Two
@@ -4413,7 +4424,7 @@ expression ...
 The `typeRef` is a header stack type.  The `typeRef` can be omitted if
 it can be inferred from context, e.g., when initializing a variable
 with a header stack type.  Each expression in the list must evaluate
-to a header of the same type as the other stack elements.  
+to a header of the same type as the other stack elements.
 
 Here is an example:
 
@@ -4636,8 +4647,8 @@ parser Tcp_option_parser(packet_in b, out Tcp_option_stack vec) {
 }
 ~End P4Example
 
-Similar to headers, the size of a header union can be determined at
-compile-time (Section [#sec-minsizeinbits]).
+Similar to headers, the size of a header union is a local compile-time known
+value (Section [#sec-minsizeinbits]).
 
 The expression `{#}` represents an invalid header union of some type,
 but it can be any header or header union type.  A P4 compiler may require an
@@ -4815,20 +4826,18 @@ limitation, such values are currently of limited utility.
 ## Reading uninitialized values and writing fields of invalid headers { #sec-uninitialized-values-and-writing-invalid-headers }
 
 As mentioned in Section [#sec-expr-hs], any reference to an element of
-a header stack `hs[index]` where `index` is a compile-time constant
-expression must give an error at compile time if the value of the
-index is out of range.  That section also defines the run time
-behavior of the expressions `hs.next` and `hs.last`, and the behaviors
-specified there take precedence over anything in this section for
-those expressions.
+a header stack `hs[index]` where `index` is a compile-time known value
+must give an error at compile time if the value of the index is out of
+range.  That section also defines the run time behavior of the
+expressions `hs.next` and `hs.last`, and the behaviors specified there
+take precedence over anything in this section for those expressions.
 
-All mentions of header stack elements in this section only apply
-for expressions `hs[index]` where `index` is a runtime variable
-expression, i.e. not a compile-time constant value.
-A P4 implementation is allowed not to support `hs[index]` where
-`index` is a runtime variable expression, but if it does support
-these expressions, the implementation should conform to the
-behaviors specified in this section.
+All mentions of header stack elements in this section only apply for
+expressions `hs[index]` where `index` is not a compile-time known
+value.  A P4 implementation may elect not to support expressions of
+the form `hs[index]` where `index` is not a compile-time known
+value. However, it does support such expressions, the implementation
+should conform to the behaviors specified in this section.
 
 The result of reading a value in any of the situations below is that
 some unspecified value will be used for that field.
@@ -4977,21 +4986,25 @@ T t2 = { s = ... }; // error: no initializer specified for fields n0 and n1
 tuple<N0, N1> p = { ... }; // initialize p with default value { 0, N1.A }
 T t3 = { ..., n0 = 2}; // error: ... must be last
 H h1 = ...;   // initialize h1 with a header that is invalid
-H h2 = { f2=5, ... };   // initialize h2 with a header that is valid, field f1 0, field f2 5
+H h2 = { f2=5, ... };   // initialize h2 with a header that is valid, field f1 0,
+                        // field f2 5
 H h3 = { ... };  // initialize h3 with a header that is valid, field f1 0, field f2 0
 ~ End P4Example
 
 # Compile-time size determination { #sec-minsizeinbits }
 
 The method calls `minSizeInBits`, `minSizeInBytes`, `maxSizeInBits`,
-and `maxSizeInBytes` can be applied to some expressions.  Each of
-these method calls evaluate to compile-time known values that return
-the minimum size in bits required to store the expression (thus the
-result type of these methods has type `int`).  None of these methods
-evaluates the expression itself.  In consequence, the expression may
-be invalid (e.g., an out-of-bounds header stack access).
+and `maxSizeInBytes` can be applied to certain expressions. These
+method calls return the minimum (or maximum) size in bits (or bytes) required to
+store the expression. Thus, the result type of these methods has type
+`int`. Except in certain situations involving type variables,
+discussed below, these method calls produce local compile-time known
+values; otherwise they produce compile-time known values. None of
+these methods evaluate the expression that is the receiver of the
+method call, so it may be invalid (e.g., an out-of-bounds header stack
+access).
 
-The method `minSizeInBytes` always returns the result of
+The method `minSizeInBytes` returns the result of
 `minSizeInBits` rounded up to the next whole number of bytes.
 In other words, for any expression `e`,
 `e.minSizeInBytes()` is equal to `(e.minSizeInBits() + 7) >> 3`.
@@ -5049,7 +5062,9 @@ These methods are defined for:
 * for a type that does contain `varbit` fields, `maxSizeInBits` is the worst-case size
   of the serialized representation of the data and `minSizeInBits` is the "best" case.
 
-Every other case is undefined and will produce a compile-time error.
+Every other case is undefined and will produce a compile-time
+error. In particular, cases involving type variables produce a
+compile-time error.
 
 # Function declarations { #sec-functions }
 
@@ -5100,7 +5115,7 @@ struct Version {
 const Version version = { 32w0, 32w0 };
 ~ End P4Example
 
-The `initializer` expression must be a compile-time known value.
+The `initializer` expression must be a local compile-time known value.
 
 ## Variables { #sec-variables }
 
@@ -5156,7 +5171,7 @@ instantiation
 ~ End P4Grammar
 
 An instantiation is written as a constructor invocation followed by a name.
-Instantiations are always executed at compilation time (Section [#sec-ct-constants]).
+Instantiations are always executed at compilation time (Section [#sec-compile-time-known]).
 The effect is to allocate an object with the specified name,
 and to bind it to the result of the constructor invocation.
 Note that instantiation arguments can be specified by name.
@@ -5296,10 +5311,10 @@ The empty statement, written `;` is a no-op.
 
 ## Block statement { #sec-block-stmt }
 
-A block statement is denoted by curly braces. It contains a
-sequence of statements and declarations, which are executed
-sequentially. The variables and constants within a
-block statement are only visible within the block.
+A block statement is denoted by curly braces. It contains a sequence
+of statements and declarations, which are executed sequentially. The
+declarations (e.g., variables and constants) within a block statement
+are only visible within the block.
 
 ~ Begin P4Grammar
 [INCLUDE=grammar.mdk:blockStatement]
@@ -5756,9 +5771,9 @@ This constitutes an important difference between `select`
 expressions and the `switch` statements found in many programming languages since the keysets of
 a `select` expression may "overlap".
 
-The typical way to use a `select` expression is to compare
-the value of a recently-extracted header field against a set of
-constant values, as in the following example:
+The typical way to use a `select` expression is to compare the value
+of a recently-extracted header field against a set of values, as in
+the following example:
 
 ~ Begin P4Example
 header IPv4_h { bit<8> protocol; /* more fields omitted */ }
@@ -6461,7 +6476,7 @@ In addition, the tables may optionally define the following properties,
 
 The compiler must set the `default_action` to `NoAction` (and also
 insert it into the list of `actions`) for tables that do not define
-the `default_action` property`.  Hence, all tables can be thought of
+the `default_action` property.  Hence, all tables can be thought of
 as having a `default_action` property, either implicitly or
 explicitly.
 
@@ -6469,18 +6484,19 @@ In addition, tables may contain architecture-specific properties (see
 Section [#sec-additional-table-properties]).
 
 A property marked as `const` cannot be changed dynamically by the
-control plane. The `key`, `actions`, and `size` properties are always
-constant, so the `const` keyword is not needed for these.
+control plane. The `key`, `actions`, and `size` properties cannot be
+modified so the `const` keyword is not needed for these.
 
 ### Table properties { #sec-table-props }
 
 #### Keys { #sec-table-keys }
 
-The `key` is a table property which specifies the data-plane
-values that should be used to look up an entry. A key is a list of
-pairs of the form `(e : m)`, where `e` is an expression that describes
-the data to be matched in the table, and `m` is a `match_kind`
-constant that describes the algorithm used to perform the lookup (see Section [#sec-match-kind-type]).
+The `key` is a table property which specifies the data-plane values
+that should be used to look up an entry. A key is a list of pairs of
+the form `(e : m)`, where `e` is an expression that describes the data
+to be matched in the table, and `m` is a `match_kind` that describes
+the algorithm used to perform the lookup (see Section
+[#sec-match-kind-type]).
 
 ~ Begin P4Grammar
 [INCLUDE=grammar.mdk:keyElementList]
@@ -6501,7 +6517,7 @@ table Fwd {
 ~ End P4Example
 
 Here the key comprises two fields from the `ipv4header`
-header: `dstAddress` and `version`. The `match_kind` constants
+header: `dstAddress` and `version`. The `match_kind` elements
 serve three purposes:
 
 - They specify the algorithm used to match data-plane values against
@@ -7037,10 +7053,10 @@ because of the `@noWarn("duplicate_priorities")` annotation.
 #### Size {#sec-size-table-property}
 
 The `size` is an optional property of a table.  When present, its
-value must always be an integer compile-time known value.  It is specified
-in units of number of table entries.
+value must always be a compile-time known value that is an integer. The `size` property
+is specified in units of number of table entries.
 
-If a table has a `size` value specified for it with value `N`, it is
+If a table is specified with a `size` property of value `N`, it is
 recommended that a compiler should choose a data plane implementation
 that is capable of storing `N` table entries.  This does not guarantee
 that an _arbitrary_ set of `N` entries can always be inserted in such
@@ -7422,7 +7438,8 @@ control Callee<T>(/* parameters omitted */) { /* body omitted */ }
 
 control Caller(/* parameters omitted */)(/* parameters omitted */) {
     apply {
-        Callee<bit<32>>.apply(/* arguments omitted */); // Callee<bit<32>> is treated as an instance
+        // Callee<bit<32>> is treated as an instance
+        Callee<bit<32>>.apply(/* arguments omitted */);
     }
 }
 ~ End P4Example
@@ -7711,33 +7728,54 @@ The evaluation of a P4 program is done in two stages:
   executed to completion, in isolation, when it receives control from the
   architecture
 
-## Compile-time known values { #sec-ct-constants }
+## Compile-time known and local compile-time known values { #sec-compile-time-known }
 
-The following are compile-time known values:
+Certain expressions in a P4 program have the property that their value
+can be determined at compile time. Moreover, for some of these
+expressions, their value can be determined only using information in
+the current scope. We call these _compile-time known values_ and
+_local compile-time known values_ respectively.
+
+The following are local compile-time known values:
 
 - Integer literals, Boolean literals, and string literals.
-- Identifiers declared in an `error`, `enum`, or `match_kind`
-  declaration.
+- Identifiers declared as constants using the `const` keyword.
+- Identifiers declared in an `error`, `enum`, or `match_kind` declaration.
 - The `default` identifier.
 - The `size` field of a value with type header stack.
 - The `_` identifier when used as a `select` expression label
-- The expression `{#}` representing an invalid header or header union
-  value.
-- Identifiers that represent declared types, actions, tables, parsers,
-  controls, or packages.
+- The expression `{#}` representing an invalid header or header union value.
+- Instances constructed by instance declarations (Section [#sec-instantiations]) and constructor invocations.
+- Identifiers that represent declared types, actions, functions, tables, parsers, controls, or packages.
+- Tuple expression where all components are local compile-time known values.
+- Structure-valued expressions, where all fields are local compile-time known values.
+- Expressions evaluating to a list type, where all elements are local compile-time known values.
+- Legal casts applied to local compile-time known values.
+- The following expressions (`+`, `-`, `|+|`, `|-|`, `*`, `/ `, `%`, `!`, `&`, `|`, `^`, `&&`, `||`, `<< `, `>>`, `~`, `/`, `>`, `<`, `==`, `!=`, `<=`, `>=`, `++`, `[:]`, `?:`) when their operands are all local compile-time known values.
+- Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`, `e.maxSizeInBits()` and `e.maxSizeInBytes()` where the type of `e` is not generic.
+
+The following are compile-time known values:
+
+- All local compile-time known values.
+- Constructor parameters (i.e., the declared parameters for a `parser`, `control`, etc.)
 - Tuple expression where all components are compile-time known values.
-- Structure-valued expressions, where all fields are compile-time
-  known values.
-- Expressions evaluating to a list type, where all elements are
-  compile-time known values.
-- Instances constructed by instance declarations (Section
-  [#sec-instantiations]) and constructor invocations.
-- A legal cast applied to a compile-time known value
-- The following expressions (`+`, `-`, `*`, `/ `, `%`, `!`, `&`, `|`, `&&`, `||`, `<< `, `>> `, `~` `, `\ `>`, `<`, `==`, `!=`, `<=`, `>=`, `++`, `[:]`, `?:`)
-  when their operands are all compile-time known values.
-- Identifiers declared as constants using the `const` keyword.
-- Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`,
-  `e.maxSizeInBits()` and `e.maxSizeInBytes()`
+- Expressions evaluating to a list type, where all elements are compile-time known values.
+- Structure-valued expressions, where all fields are compile-time known values.
+- Expressions evaluating to a list type, where all elements are compile-time known values.
+- Legal casts applied to compile-time known values.
+- The following expressions (`+`, `-`, `|+|`, `|-|`, `*`, `/ `, `%`, `cast`, `!`, `&`, `|`, `^`, `&&`, `||`, `<< `, `>> `, `~`, `/`, `>`, `<`, `==`, `!=`, `<=`, `>=`, `++`, `[:]`, `?:`) when their operands are all compile-time known values.
+- Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`, `e.maxSizeInBits()` and `e.maxSizeInBytes()` where the the type of `e` is generic.
+
+Intuitively, the main difference between _compile-time known values_
+and _local compile-time known values_ is that the former also contains
+constructor parameters. The distinction is important when it comes to
+defining the meaning of features like types. For example, in the type
+`bit<e>`, the expression `e` must be a local compile-time known
+value. Suppose instead that `e` were a constructor parameter---i.e.,
+merely a compile-time known value. In this situation, it would be
+impossible to resolve `bit<e>` to a concrete type using purely local
+information---we would have to wait until the constructor was
+instantiated and the value of `e` known.
 
 ## Compile-time Evaluation { #sec-ct-eval }
 
@@ -8170,6 +8208,7 @@ diagnostics.
 The P4 core library contains two overloaded declarations for a
 `static_assert` function, as follows:
 
+~ Begin P4Example
 /// Static assert evaluates a boolean expression
 /// at compilation time.  If the expression evaluates to
 /// false, compilation is stopped and the corresponding message is printed.
@@ -8177,9 +8216,10 @@ extern bool static_assert(bool check, string message);
 
 /// Like the above but using a default message.
 extern bool static_assert(bool check);
+~ End P4Example
 
 These functions both return boolean values.  Since the parameters are
-directionless, these functions require compile-time constant values as
+directionless, these functions require compile-time known values as
 arguments, thus they can be used to enforce compile-time invariants.
 Since P4 does not allow statements at the program top-level (outside
 of apply blocks), these functions can be used at the top-level by
@@ -8282,9 +8322,8 @@ a key and a value `expression`. Note the syntax for `expression` is rich, see
 Appendix [#sec-grammar] for details.
 
 All `expression`s within a `structuredAnnotationBody` must be compile-time known
-values, either literals or expressions requiring compile-time evaluation, with a
-result type that is one of: string literals, arbitrary-precision integer, or
-boolean. Structured `expression`s (e.g. an `expression` containing an
+values with a result type that is either: `string`, `int`, or `bool`.
+In particular, structured `expression`s (e.g. an `expression` containing an
 `expressionList`, a `kvList`, etc.) are not allowed. Note that P4Runtime
 information (P4Info) may stipulate additional restrictions. For example, an
 integer expression might be limited to 64-bit values.
@@ -8580,12 +8619,20 @@ The P4 compiler should provide:
 
 - Errors when annotations are used incorrectly (e.g., an annotation
   expecting a parameter but used without arguments, or with arguments
-  of the wrong type
+  of the wrong type)
 - Warnings for unknown annotations.
 
 # Appendix: Revision History { #sec-revision-history; @h1:"A" }
 
-## Summary of changes made in version 1.2.4
+## Summary of changes made in unreleased version
+
+## Summary of changes made in version 1.2.5, released October 11, 2024
+
+* Improved type nesting rules (Section[#sec-type-nesting]).
+* Clarified that directionless extern parameters are passed by reference.
+* Introduced distinction between local compile-time known and compile-time known values (Section[#sec-compile-time-known]).
+
+## Summary of changes made in version 1.2.4,released May 15, 2023
 
 * Added header stack expressions (Section [#sec-hs-init]).
 * Allow casts from a type to itself (Section [#sec-casts]).
@@ -8635,7 +8682,7 @@ The P4 compiler should provide:
 * Added `match_kind` as a base type (Section [#sec-match-kind-type]).
 * Removed structure initializers as they are subsumed by structure-valued expressions (Section [#sec-structure-expressions]).
 * Specified operations on values typed as type variables (Section [#sec-type-variable-operations]).
-* Clarified semantics of compile-time known values (Section [#sec-ct-constants]).
+* Clarified semantics of compile-time known values (Section [#sec-compile-time-known]).
 * Clarified semantics of directionless parameters (Section [#sec-calling-convention]).
 * Clarified semantics of arbitrary precision integers (Section [#sec-arbitrary-precision-integers]).
 * Clarified semantics of bit slices, shifts, and concatenation (Section [#sec-bit-ops]).


### PR DESCRIPTION
Updated the text of the P4-16 specification fileds, adoc and .mdk,  to the latest version.